### PR TITLE
Make translate_shell better support the translation of comments start…

### DIFF
--- a/lua/translate/preset/parse_after/translate_shell.lua
+++ b/lua/translate/preset/parse_after/translate_shell.lua
@@ -15,6 +15,13 @@ function M.cmd(text, _)
 
     local lines = vim.split(text, crlf)
 
+    for i, line in ipairs(lines) do
+        if line:match("{{T%-C}}") then
+            vim.pretty_print("yes")
+            lines[i] = line:gsub("{{T%-C}}", "/")
+        end
+    end
+
     return lines
 end
 

--- a/lua/translate/preset/parse_before/translate_shell.lua
+++ b/lua/translate/preset/parse_before/translate_shell.lua
@@ -2,12 +2,10 @@ local M = {}
 
 function M.cmd(lines, pos, _)
     for i, line in ipairs(lines) do
-        local slash = line:match("^/*")
-        pos[i].col[1] = pos[i].col[1] + #slash
-
-        lines[i] = line:sub(#slash + 1)
+        if line:match("/") then
+            lines[i] = line:gsub("/", "{{T-C}}")
+        end
     end
-
     return lines
 end
 


### PR DESCRIPTION
Use placeholders instead of `/` before starting translation, and replace placeholders with `/` after translation is complete 
