### PR TITLE
Added before and after replace dictionaries for different translators

### DIFF
--- a/lua/translate/config.lua
+++ b/lua/translate/config.lua
@@ -7,6 +7,7 @@ M._preset = {
         concat = require("translate.preset.parse_before.concat"),
         no_handle = require("translate.preset.parse_before.no_handle"),
         translate_shell = require("translate.preset.parse_before.translate_shell"),
+        replace_char = require("translate.preset.parse_before.replace_char"),
     },
     command = {
         translate_shell = require("translate.preset.command.translate_shell"),
@@ -23,6 +24,7 @@ M._preset = {
         translate_shell = require("translate.preset.parse_after.translate_shell"),
         deepl = require("translate.preset.parse_after.deepl"),
         google = require("translate.preset.parse_after.google"),
+        replace_char = require("translate.preset.parse_after.replace_char"),
     },
     output = {
         floating = require("translate.preset.output.floating"),
@@ -150,6 +152,11 @@ function M.get_keys(mode)
     local keys = vim.tbl_keys(M.config[mode])
     keys = vim.list_extend(keys, vim.tbl_keys(M._preset[mode]))
     return keys
+end
+
+--@return string
+function M.get_translate_command()
+    return M.config.default.command
 end
 
 return M

--- a/lua/translate/init.lua
+++ b/lua/translate/init.lua
@@ -2,6 +2,7 @@ local luv = vim.loop
 
 local config = require("translate.config")
 local select = require("translate.util.select")
+local replace = require("translate.util.replace")
 local create_command = require("translate.command").create_command
 
 local M = {}
@@ -69,6 +70,9 @@ function M._translate(pos, cmd_args)
         set_to_top(parse_after, config._preset.parse_after.google.cmd)
     end
 
+    set_to_top(parse_before, config._preset.parse_before.replace_char.cmd)
+    set_to_top(parse_after, config._preset.parse_after.replace_char.cmd)
+
     local lines = M._selection(pos)
     pos._lines_selected = lines
 
@@ -133,6 +137,7 @@ end
 ---@param opt table
 function M.setup(opt)
     config.setup(opt)
+    replace.setup()
     create_command(M.translate)
     vim.g.loaded_translate_nvim = true
 end

--- a/lua/translate/preset/parse_after/head.lua
+++ b/lua/translate/preset/parse_after/head.lua
@@ -13,7 +13,11 @@ function M.cmd(lines, pos)
     local results = {}
 
     for i, text in ipairs(lines) do
-        local group = pos._group[i]
+        local group = {}
+
+        if pos._group then
+            group = pos._group[i]
+        end
 
         local widths_origin = {}
         local sum_width_origin = 0

--- a/lua/translate/preset/parse_after/replace_char.lua
+++ b/lua/translate/preset/parse_after/replace_char.lua
@@ -1,0 +1,9 @@
+local replace = require("translate.util.replace")
+
+local M = {}
+
+function M.cmd(text, pos, _)
+    return replace.run_after_replace_symbol(text, pos)
+end
+
+return M

--- a/lua/translate/preset/parse_before/replace_char.lua
+++ b/lua/translate/preset/parse_before/replace_char.lua
@@ -1,0 +1,9 @@
+local replace = require("translate.util.replace")
+
+local M = {}
+
+function M.cmd(lines, pos, _)
+    return replace.run_before_replace_symbol(lines, pos)
+end
+
+return M

--- a/lua/translate/preset/parse_before/translate_shell.lua
+++ b/lua/translate/preset/parse_before/translate_shell.lua
@@ -1,13 +1,6 @@
 local M = {}
 
 function M.cmd(lines, pos, _)
-    for i, line in ipairs(lines) do
-        local slash = line:match("^/*")
-        pos[i].col[1] = pos[i].col[1] + #slash
-
-        lines[i] = line:sub(#slash + 1)
-    end
-
     return lines
 end
 

--- a/lua/translate/util/replace.lua
+++ b/lua/translate/util/replace.lua
@@ -1,0 +1,85 @@
+local M = {
+    before = {},
+    after = {},
+    translate_command = { "google", "deepl_free", "deepl_pro", "translate_shell" },
+}
+
+function M.setup()
+    for _, cmd in ipairs(M.translate_command) do
+        M["before"][cmd] = {}
+        M["after"][cmd] = {}
+    end
+
+    -- put options: google、deepl_free、deepl_pro、translate_shell、all
+    M.put_symbol_to_after("translate_shell", "u003d", "=")
+    M.put_symbol_to_after("translate_shell", "＃", "#")
+    M.put_symbol_to_before_and_after("translate_shell", "/", "{{@C@}}")
+end
+
+-- add character groups to the before dictionary of a specific translator
+---@param command string
+---@param char string
+---@param rep string
+function M.put_symbol_to_before(command, char, rep)
+    if command == "all" then
+        for _, cmd in ipairs(M.translate_command) do
+            M["before"][cmd][char] = rep
+        end
+    else
+        M["before"][command][char] = rep
+    end
+end
+
+-- add character groups to the after dictionary of a specific translator
+---@param command string
+---@param char string
+---@param rep string
+function M.put_symbol_to_after(command, char, rep)
+    if command == "all" then
+        for _, cmd in ipairs(M.translate_command) do
+            M["after"][cmd][char] = rep
+        end
+    else
+        M["after"][command][char] = rep
+    end
+end
+
+-- add character groups to the before and after dictionary of a specific translator
+---@param command string
+---@param char string
+---@param rep string
+function M.put_symbol_to_before_and_after(command, char, rep)
+    if command == "all" then
+        for _, cmd in ipairs(M.translate_command) do
+            M["before"][cmd][char] = rep
+            M["after"][cmd][rep] = char
+        end
+    else
+        M["before"][command][char] = rep
+        M["after"][command][rep] = char
+    end
+end
+
+function M.run_before_replace_symbol(lines, pos)
+    local cmd = require("translate.config").get_translate_command()
+    for i, line in ipairs(lines) do
+        for k, v in pairs(M["before"][cmd]) do
+            if line:match(k) then
+                lines[i] = line:gsub(k, v)
+            end
+        end
+    end
+    return lines
+end
+
+function M.run_after_replace_symbol(text, pos)
+    local cmd = require("translate.config").get_translate_command()
+    for k, v in pairs(M["after"][cmd]) do
+        if text:match(k) then
+            text = text:gsub(k, v)
+        end
+    end
+    return text
+end
+
+return M


### PR DESCRIPTION
Added before and after replace dictionaries for different translators

I've added some common potentially problematic symbols to the `translate-shell` translator to make the translation look as normal as possible.

For the first two examples, I've been using other methods for about half a year, and I'm sure merging it now won't cause any problems.

- `=` will be replaced by `u003d` in `translate-shell` translation results, I don't know if it's a language-specific reason
- Few English `#` will appear `＃` when translated into Chinese
- Unable to translate content starting with `/` (use placeholder `/` to fix it)

In addition to that, it fixes a very hard-to-trigger bug that would appear when you only set `parse_before` and not set `parse_after`.

```
require("translate").setup({
    default = {
        command = "translate_shell",
        output = "floating",
        parse_before = "trim",
        -- parse_after = "rep",
    }
})
```