### PR TITLE
fix: add zindex to config

### DIFF
--- a/doc/translate-nvim.txt
+++ b/doc/translate-nvim.txt
@@ -370,6 +370,7 @@ Options passed to the presets.
 			col = 1,
 			border = "single",
 			filetype = "translate",
+			zindex = 50,
 		}
 
 		The option passed as the 3rd argument of |nvim_open_win()|.

--- a/lua/translate/config.lua
+++ b/lua/translate/config.lua
@@ -82,6 +82,7 @@ M.config = {
         col = 1,
         border = "single",
         filetype = "translate",
+        zindex = 50,
       },
       split = {
         position = "top",

--- a/lua/translate/preset/output/floating.lua
+++ b/lua/translate/preset/output/floating.lua
@@ -30,6 +30,7 @@ function M.cmd(lines, _)
     row = options.row,
     col = options.col,
     border = options.border,
+    zindex = options.zindex,
   })
 
   M.window._current = { win = win, buf = buf }


### PR DESCRIPTION
## Summary
The default zindex for windows created with nvim_open_win is 50.
It is often placed below other windows.
This change allows the user to change the zindex to any value.

## Befor
![translate_before](https://github.com/uga-rosa/translate.nvim/assets/100141359/248b62d6-74fe-4608-aed1-b41e1930c876)

## After
I set zindex to 300.
```lua
require("translate").setup({
  preset = {
    output = {
      floating = {
        zindex = 300
      }
    }
  }
})

```
![translate_after](https://github.com/uga-rosa/translate.nvim/assets/100141359/8c764478-a54b-4634-a0d4-be6dfdc05e4a)
