### PR TITLE
Update vim LSP usage to avoid deprecation warning

### DIFF
--- a/lua/translate/kit/init.lua
+++ b/lua/translate/kit/init.lua
@@ -36,6 +36,10 @@ kit.uuid = setmetatable({
   end,
 })
 
+
+-- https://neovim.io/doc/user/deprecated.html#vim.tbl_islist()
+local islist = vim.islist or vim.tbl_islist
+
 ---Merge two tables.
 ---@generic T
 ---NOTE: This doesn't merge array-like table.
@@ -43,8 +47,8 @@ kit.uuid = setmetatable({
 ---@param tbl2 T
 ---@return T
 function kit.merge(tbl1, tbl2)
-  local is_dict1 = type(tbl1) == "table" and (not vim.tbl_islist(tbl1) or vim.tbl_isempty(tbl1))
-  local is_dict2 = type(tbl2) == "table" and (not vim.tbl_islist(tbl2) or vim.tbl_isempty(tbl2))
+  local is_dict1 = type(tbl1) == "table" and (not islist(tbl1) or vim.tbl_isempty(tbl1))
+  local is_dict2 = type(tbl2) == "table" and (not islist(tbl2) or vim.tbl_isempty(tbl2))
   if is_dict1 and is_dict2 then
     local new_tbl = {}
     for k, v in pairs(tbl2) do
@@ -93,7 +97,7 @@ end
 ---@return table
 function kit.to_array(value)
   if type(value) == "table" then
-    if vim.tbl_islist(value) or vim.tbl_isempty(value) then
+    if islist(value) or vim.tbl_isempty(value) then
       return value
     end
   end
@@ -104,7 +108,7 @@ end
 ---@param value any
 ---@return boolean
 function kit.is_array(value)
-  return type(value) == "table" and (vim.tbl_islist(value) or vim.tbl_isempty(value))
+  return type(value) == "table" and (islist(value) or vim.tbl_isempty(value))
 end
 
 ---Reverse the array.


### PR DESCRIPTION
The usage of `vim.tbl_islist()` is throwing deprecation warnings when I rebulid my VIM config and other inconvenient times. This should shim the usage so that the new API is used when available with fallback to the old one for continued backwards compatibility.

Note this was deprecated in 0.10.0.

https://neovim.io/doc/user/deprecated.html#vim.tbl_islist()
